### PR TITLE
added youtube-dl as prerequisite

### DIFF
--- a/bin/steps/pip-install
+++ b/bin/steps/pip-install
@@ -41,6 +41,8 @@ if [ ! "$SKIP_PIP_INSTALL" ]; then
         exit 1
     fi
 
+    # install youtube-dl first because pafy requires youtube-dl before installation
+    /app/.heroku/python/bin/pip install youtube-dl
     /app/.heroku/python/bin/pip install -r "$BUILD_DIR/requirements.txt" --exists-action=w --src=/app/.heroku/src --disable-pip-version-check --no-cache-dir 2>&1 | tee "$WARNINGS_LOG" | cleanup | indent
     PIP_STATUS="${PIPESTATUS[0]}"
     set -e


### PR DESCRIPTION
pafy requires youtube-dl to be installed prior to its installation, so install youtube-dl first, then install requirements.txt